### PR TITLE
Add uname command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Commands
 
 - [ ] acpi
-- [ ] arch
+- [x] arch
 - [x] ascii
 - [ ] base64
 - [ ] basename
@@ -200,7 +200,7 @@
 - [ ] tunctl
 - [ ] ulimit
 - [ ] umount
-- [ ] uname
+- [x] uname
 - [ ] uniq
 - [ ] unix2dos
 - [ ] unlink

--- a/src/main.zig
+++ b/src/main.zig
@@ -45,6 +45,7 @@ const commands = comptime blk: {
         .{ .name = "arch", .func = arch },
         .{ .name = "ascii", .func = ascii },
         .{ .name = "base64", .func = base64 },
+        .{ .name = "uname", .func = uname },
     };
 
     sort(Command, &ret, {}, lessThan);


### PR DESCRIPTION
Uses `std.os.uname().machine` in place of the deprecated `std.builtin.arch` in the `arch` command.
Adds the `uname` command.
Adds usage/--help messages.